### PR TITLE
chore: new hook in .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,3 +3,9 @@
   entry: aquasec/trivy:0.37.1 fs --cache-dir /src/.pre-commit-trivy-cache --exit-code 1
   language: docker_image
   pass_filenames: false
+
+- id: trivyconfig-docker
+  name: trivyconfig-docker
+  entry: aquasec/trivy:0.37.1 config --cache-dir /src/.pre-commit-trivy-cache exit-code 1
+  language: docker_image
+  pass_filenames: false


### PR DESCRIPTION
Adds a new hook for doing IaC config scanning https://aquasecurity.github.io/trivy/v0.38/docs/misconfiguration/scanning/.