### PR TITLE
Update trivy docker image tag for trivyfs and trivyconfig to 0.44

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,11 +1,11 @@
 - id: trivyfs-docker
   name: trivyfs-docker
-  entry: aquasec/trivy:0.40.0 fs --cache-dir /src/.pre-commit-trivy-cache --exit-code 1
+  entry: aquasec/trivy:0.44.0 fs --cache-dir /src/.pre-commit-trivy-cache --exit-code 1
   language: docker_image
   pass_filenames: false
 
 - id: trivyconfig-docker
   name: trivyconfig-docker
-  entry: aquasec/trivy:0.40.0 config --cache-dir /src/.pre-commit-trivy-cache --exit-code 1
+  entry: aquasec/trivy:0.44.0 config --cache-dir /src/.pre-commit-trivy-cache --exit-code 1
   language: docker_image
   pass_filenames: false


### PR DESCRIPTION
Enables the use of properly skipping files and directories with globbing patterns.
https://github.com/aquasecurity/trivy/issues/3754
https://github.com/aquasecurity/trivy/pull/4854

```
- repo: https://github.com/mxab/pre-commit-trivy.git
  rev: v0.5.2
  hooks:
  -   id: trivyconfig-docker
      args:
        - --skip-dirs="**/.terraform"
        - --skip-dirs="**/.terragrunt-cache"
        - .
```